### PR TITLE
Do not exclude vue-loader from node_modules

### DIFF
--- a/webpack.js
+++ b/webpack.js
@@ -41,7 +41,6 @@ module.exports = {
 			{
 				test: /\.vue$/,
 				loader: 'vue-loader',
-				exclude: /node_modules/,
 			},
 			{
 				test: /\.js$/,


### PR DESCRIPTION
Otherwise building with packages that just export regular vue modules will fail, e.g. when using vue-material-design-icons

Also I don't see any reason to generally exclude those, if a package ships .vue files, they need to be handled by the app.