### PR TITLE
Don't bundle comments

### DIFF
--- a/webpack.js
+++ b/webpack.js
@@ -63,7 +63,7 @@ module.exports = {
 						comments: false,
 					}
 				},
-				extractComments: false,
+				extractComments: true,
 			}),
 		],
 	},

--- a/webpack.js
+++ b/webpack.js
@@ -58,6 +58,11 @@ module.exports = {
 		minimize: !isDev,
 		minimizer: [
 			new TerserPlugin({
+				terserOptions: {
+					output: {
+						comments: false,
+					}
+				},
 				extractComments: false,
 			}),
 		],


### PR DESCRIPTION
This PR stops bundling comments in the javascript file. For Tasks this reduces the bundle size by 60 kByte at least. In order to still ship the license comments, I set `extractComments` to true now, which creates a separate file with the license comments.