### PR TITLE
Define the library name so that devtools sourcemaps can have a proper namespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nextcloud/webpack-vue-config",
-	"version": "4.0.3-alpha.1",
+	"version": "4.0.3-alpha.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nextcloud/webpack-vue-config",
-	"version": "4.0.3-alpha.0",
+	"version": "4.0.3-alpha.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nextcloud/webpack-vue-config",
-	"version": "4.0.2",
+	"version": "4.0.3-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nextcloud/webpack-vue-config",
-	"version": "4.0.2",
+	"version": "4.0.3-alpha.0",
 	"description": "A webpack vue config for nextcloud apps",
 	"author": "John Molakvoæ <skjnldsv@protonmail.com>",
 	"license": "AGPL-3.0-or-later",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nextcloud/webpack-vue-config",
-	"version": "4.0.3-alpha.0",
+	"version": "4.0.3-alpha.1",
 	"description": "A webpack vue config for nextcloud apps",
 	"author": "John Molakvoæ <skjnldsv@protonmail.com>",
 	"license": "AGPL-3.0-or-later",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nextcloud/webpack-vue-config",
-	"version": "4.0.3-alpha.1",
+	"version": "4.0.3-alpha.2",
 	"description": "A webpack vue config for nextcloud apps",
 	"author": "John Molakvoæ <skjnldsv@protonmail.com>",
 	"license": "AGPL-3.0-or-later",

--- a/webpack.js
+++ b/webpack.js
@@ -49,6 +49,14 @@ module.exports = {
 		publicPath: '/js/',
 		filename: `${appName}-[name].js?v=[contenthash]`,
 		chunkFilename: `${appName}-[name].js?v=[contenthash]`,
+		// Make sure sourcemaps have a proper path and do not
+		// leak local paths https://github.com/webpack/webpack/issues/3603
+		devtoolNamespace: appName,
+		devtoolModuleFilenameTemplate(info) {
+			const rootDir = process.cwd()
+			const rel = path.relative(rootDir, info.absoluteResourcePath)
+			return `webpack:///${appName}/${rel}`
+		},
 	},
 
 	optimization: {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14975046/114989910-3b2db180-9e98-11eb-9397-6d9ccb295644.png)

By doing so we override the path of the sourcemap and avoid leaking local relative paths to it.
And because we keep shipping the bundles in some repos, the sourcemap was always different depending on who built it

We are using `process.cwd()` meaning the path might change if you build the app from another directory than the location of the package.json.
But the other ways to get the root pkg (like using https://www.npmjs.com/package/pkg-dir), were not working as intended as the method is async and using `__dirname` refers to this library webpack.js file instead of the app's webpack file (not resolving the node_module paths).

refs: 
- https://github.com/nextcloud/notifications/pull/925
- https://github.com/webpack/webpack/issues/3603
- https://webpack.js.org/configuration/output/#outputdevtoolmodulefilenametemplate

Not stricly related, but relevant https://github.com/webpack/webpack/issues/13163