### PR TITLE
Tweak config to support HMR

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,34 @@ module.exports = webpackConfig
 		"build": "NODE_ENV=production webpack --progress --config webpack.js",
 		"dev": "NODE_ENV=development webpack --progress --config webpack.js",
 		"watch": "NODE_ENV=development webpack --progress --watch --config webpack.js",
+		"serve": "NODE_ENV=development webpack serve --progress --config webpack.js",
 }
 ...
 ```
 
+## Hot module replacement
+
+To enjoy hot module replacement, follow those instructions:
+
+- Install the [`HMREnabler`](https://github.com/nextcloud/hmr_enabler) server app. This will tweak the CSP header so do not use it in production !
+- Add the `serve` script to your `package.json` as listed above.
+- Add `js/*hot-update.*` to you `.gitignore`. This is necessary because we write every files on disk so the nextcloud server can serve them.
+- Add the following line in your Vue app entry file so Webpack knows where to fetch updates, [see this example](https://github.com/nextcloud/app-tutorial/blob/master/src/main.js). You might not need it as it default to `/apps/<your_app_name>/js/`.
+
+```js
+__webpack_public_path__ = generateFilePath(appName, '', 'js/')
+```
+
+You can then start you dev serve with `npm serve` or `make serve-js` if you added this step in your makefile.
+
+If your nextcloud hostname is different from `localhost`, you need to start the server like so:
+
+```shell
+npm run serve -- --allowed-hosts your-hostname.example
+```
+
 ## Extend with your own configs
+
 Here is an example on how to add your own  config to the base one
 
 ```js

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
 		"vue-loader": "^15.9.6",
 		"vue-template-compiler": "^2.6.12",
 		"webpack": "^5.4.0",
-		"webpack-cli": "^4.5.0"
+		"webpack-cli": "^4.5.0",
+		"webpack-dev-server": "^3.11.2"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.13.10",
@@ -56,6 +57,7 @@
 		"vue-loader": "^15.9.6",
 		"vue-template-compiler": "^2.6.12",
 		"webpack": "^5.4.0",
-		"webpack-cli": "^4.5.0"
+		"webpack-cli": "^4.5.0",
+		"webpack-dev-server": "^3.11.2"
 	}
 }

--- a/webpack.js
+++ b/webpack.js
@@ -38,6 +38,7 @@ console.info('Building', appName, appVersion, '\n')
 const rules = require('./rules')
 
 module.exports = {
+	target: 'web',
 	mode: buildMode,
 	devtool: isDev ? 'cheap-source-map' : 'source-map',
 
@@ -46,7 +47,7 @@ module.exports = {
 	},
 	output: {
 		path: path.resolve('./js'),
-		publicPath: '/js/',
+		publicPath: path.join('/apps/', appName, '/js/'),
 		filename: `${appName}-[name].js?v=[contenthash]`,
 		chunkFilename: `${appName}-[name].js?v=[contenthash]`,
 		// Make sure sourcemaps have a proper path and do not
@@ -59,6 +60,16 @@ module.exports = {
 		},
 	},
 
+	devServer: {
+		hot: true,
+		port: 3000,
+		writeToDisk: true,
+		host: '127.0.0.1',
+		headers: {
+			'Access-Control-Allow-Origin': '*',
+		},
+	},
+	
 	optimization: {
 		splitChunks: {
 			automaticNameDelimiter: '-',


### PR DESCRIPTION
Tweak the Webpack config to support hot module reloading.

- Set the target to `web` (needed because of that: https://github.com/webpack/webpack-dev-server/issues/2758).
- Change the `publicPath` so HMR knows where to fetch updates. This can be https://github.com/nextcloud/webpack-vue-config/pull/107#issue-625028311 as stated in the readme.
- Add basic config for `devServer`.