### PR TITLE
Always use named chunk ids

### DIFF
--- a/webpack.js
+++ b/webpack.js
@@ -71,6 +71,7 @@ module.exports = {
 	},
 	
 	optimization: {
+		chunkIds: 'named',
 		splitChunks: {
 			automaticNameDelimiter: '-',
 		},


### PR DESCRIPTION
With webpack 5 deterministic chunk ids would be used by default when building in production mode, while that is no issue in general using named chunks gives the benefit of static filenames which is especially nice for Nextcloud apps that are shipped and therefore commit the js assets to the repo.