### PR TITLE
Don't fail build by linter on development

### DIFF
--- a/webpack.js
+++ b/webpack.js
@@ -96,11 +96,13 @@ module.exports = {
 		new ESLintPlugin({
 			extensions: ['js', 'vue'],
 			files: 'src',
+			failOnError: !isDev,
 		}),
 
 		new VueLoaderPlugin(),
 		new StyleLintPlugin({
 			files: 'src/**/*.{css,scss,vue}',
+			failOnError: !isDev,
 		}),
 
 		// Make sure we auto-inject node polyfills on demand


### PR DESCRIPTION
As we shortly discussed on the Frontender-Chat, it is quite annoying if HMR does not work due to dumb or even temporary linting errors. Typical dev-cycle is to care about missing linting from time to time, but not on each single build.

This now disables the build-fail on linting-errors during development. So linting-errors are still shown on console, but one is still able to use the built js. This behaviour has acutally been there on "npm run watch", but now also works with "npm run serve". 😊 