### PR TITLE
Limit webpack update to patch versions of 5.46

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"stylelint-webpack-plugin": "^3.0.1",
 		"vue-loader": "^15.9.6",
 		"vue-template-compiler": "^2.6.12",
-		"webpack": "^5.46.0",
+		"webpack": "~5.46.0",
 		"webpack-cli": "^4.5.0",
 		"webpack-dev-server": "^4.0.0"
 	},
@@ -58,7 +58,7 @@
 		"stylelint-webpack-plugin": "^3.0.1",
 		"vue-loader": "^15.9.6",
 		"vue-template-compiler": "^2.6.12",
-		"webpack": "^5.46.0",
+		"webpack": "~5.46.0",
 		"webpack-cli": "^4.5.0",
 		"webpack-dev-server": "^4.0.0"
 	}


### PR DESCRIPTION
`^5.46.0` targets the next highest minor version, we don't want that yet. Change to `~5.46.0` to only target patches.