### PR TITLE
Fix HMR

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"vue-loader": "^15.9.6",
 		"vue-template-compiler": "^2.6.12",
 		"webpack": "~5.64.0",
-		"webpack-cli": "^4.5.0",
+		"webpack-cli": "^4.7.0",
 		"webpack-dev-server": "^4.0.0"
 	},
 	"devDependencies": {
@@ -59,7 +59,7 @@
 		"vue-loader": "^15.9.6",
 		"vue-template-compiler": "^2.6.12",
 		"webpack": "~5.64.0",
-		"webpack-cli": "^4.5.0",
+		"webpack-cli": "^4.7.0",
 		"webpack-dev-server": "^4.0.0"
 	}
 }

--- a/webpack.js
+++ b/webpack.js
@@ -62,9 +62,14 @@ module.exports = {
 
 	devServer: {
 		hot: true,
-		port: 3000,
-		writeToDisk: true,
 		host: '127.0.0.1',
+		port: 3000,
+		client: {
+			overlay: false,
+		},
+		devMiddleware: {
+			writeToDisk: true,
+		},
 		headers: {
 			'Access-Control-Allow-Origin': '*',
 		},


### PR DESCRIPTION
Fixing breaking change since webpack-dev-server v4 and disabling the new (annoying) overlay. Thus HMR is usable again.