### PR TITLE
Unpin webpack version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
 				"stylelint-webpack-plugin": "^3.1.0",
 				"vue-loader": "^15.9.8",
 				"vue-template-compiler": "^2.6.14",
-				"webpack": "~5.46.0",
+				"webpack": "^5.66.0",
 				"webpack-cli": "^4.9.1",
 				"webpack-dev-server": "^4.7.2"
 			}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"stylelint-webpack-plugin": "^3.1.0",
 		"vue-loader": "^15.9.8",
 		"vue-template-compiler": "^2.6.14",
-		"webpack": "~5.46.0",
+		"webpack": "^5.66.0",
 		"webpack-cli": "^4.9.1",
 		"webpack-dev-server": "^4.7.2"
 	},


### PR DESCRIPTION
https://github.com/webpack/webpack/pull/14628 is now merged, it should be safe to unpin the webpack version.

Let's wait until the equivalent server's PR is all green: https://github.com/nextcloud/server/pull/30632