### PR TITLE
Do not enforce file extensions

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -74,7 +74,7 @@ module.exports = {
 			'Access-Control-Allow-Origin': '*',
 		},
 	},
-	
+
 	optimization: {
 		chunkIds: 'named',
 		splitChunks: {
@@ -121,6 +121,7 @@ module.exports = {
 
 	resolve: {
 		extensions: ['*', '.js', '.vue'],
+		enforceExtension: false,
 		symlinks: false,
 	},
 }


### PR DESCRIPTION
Set the [enforceExtension option](https://webpack.js.org/configuration/resolve/#resolveenforceextension)

In future we may want to require extensions to stay up-to-date with the ecosystem e.g. [Node.js 14 docs](https://nodejs.org/docs/latest-v14.x/api/esm.html#esm_mandatory_file_extensions)

Also see https://github.com/nextcloud/eslint-config/pull/292