### PR TITLE
Allow localhost

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,6 +62,7 @@ module.exports = {
 		hot: true,
 		host: '127.0.0.1',
 		port: 3000,
+		allowedHosts: ['.localhost'],
 		client: {
 			overlay: false,
 		},


### PR DESCRIPTION
Currently for me, the devserver is complaining about a wrong 'user'-host of the devserver. This leads to a permanent dis/re-connecting of the devserver.
This commit solves the problem on localhost and all of its subdomains. I'm not sure, if anybody uses other domains, that we should add here...?! Alternative would be to set allowedHosts to all, however this is not recommended in devserver docs.

https://webpack.js.org/configuration/dev-server/#devserverallowedhosts

![grafik](https://user-images.githubusercontent.com/47433654/161153602-8be9d53d-9213-4c1d-bd97-50878101418c.png)
