### PR TITLE
Put vue as dependency to sync with vue-template-compiler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "sass": "^1.55.0",
         "sass-loader": "^13.1.0",
         "style-loader": "^3.3.1",
+        "vue": "^2.7.13",
         "vue-loader": "^15.10.0",
         "vue-template-compiler": "^2.7.13",
         "webpack": "^5.74.0",
@@ -314,7 +315,6 @@
       "version": "7.19.6",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.6.tgz",
       "integrity": "sha512-h1IUp81s2JYJ3mRkdxJgs4UvmSsRvDrx5ICSJbPvtWYv5i1nTBGcBpnog+89rAFMwvvru6E5NUHdBe01UeSzYA==",
-      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -611,6 +611,41 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "2.7.13",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.13.tgz",
+      "integrity": "sha512-zzu2rLRZlgIU+OT3Atbr7Y6PG+LW4wVQpPfNRrGDH3dM9PsrcVfa+1pKb8bW467bGM3aDOvAnsYLWVpYIv3GRg==",
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.18.4",
+        "postcss": "^8.4.14",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/postcss": {
+      "version": "8.4.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.18.tgz",
+      "integrity": "sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/@vue/component-compiler-utils": {
@@ -1880,6 +1915,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
+      "peer": true
     },
     "node_modules/de-indent": {
       "version": "1.0.2",
@@ -3766,10 +3807,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
-      "dev": true,
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -4175,8 +4215,7 @@
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -4945,7 +4984,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4954,7 +4992,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5392,6 +5429,16 @@
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true
+    },
+    "node_modules/vue": {
+      "version": "2.7.13",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.13.tgz",
+      "integrity": "sha512-QnM6ULTNnPmn71eUO+4hdjfBIA3H0GLsBnchnI/kS678tjI45GOUZhXd0oP/gX9isikXz1PAzSnkPspp9EUNfQ==",
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-sfc": "2.7.13",
+        "csstype": "^3.1.0"
+      }
     },
     "node_modules/vue-hot-reload-api": {
       "version": "2.3.4",
@@ -6027,8 +6074,7 @@
     "@babel/parser": {
       "version": "7.19.6",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.6.tgz",
-      "integrity": "sha512-h1IUp81s2JYJ3mRkdxJgs4UvmSsRvDrx5ICSJbPvtWYv5i1nTBGcBpnog+89rAFMwvvru6E5NUHdBe01UeSzYA==",
-      "dev": true
+      "integrity": "sha512-h1IUp81s2JYJ3mRkdxJgs4UvmSsRvDrx5ICSJbPvtWYv5i1nTBGcBpnog+89rAFMwvvru6E5NUHdBe01UeSzYA=="
     },
     "@babel/template": {
       "version": "7.18.10",
@@ -6298,6 +6344,30 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@vue/compiler-sfc": {
+      "version": "2.7.13",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.13.tgz",
+      "integrity": "sha512-zzu2rLRZlgIU+OT3Atbr7Y6PG+LW4wVQpPfNRrGDH3dM9PsrcVfa+1pKb8bW467bGM3aDOvAnsYLWVpYIv3GRg==",
+      "peer": true,
+      "requires": {
+        "@babel/parser": "^7.18.4",
+        "postcss": "^8.4.14",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "8.4.18",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.18.tgz",
+          "integrity": "sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==",
+          "peer": true,
+          "requires": {
+            "nanoid": "^3.3.4",
+            "picocolors": "^1.0.0",
+            "source-map-js": "^1.0.2"
+          }
+        }
       }
     },
     "@vue/component-compiler-utils": {
@@ -7302,6 +7372,12 @@
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
+    },
+    "csstype": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
+      "peer": true
     },
     "de-indent": {
       "version": "1.0.2",
@@ -8706,10 +8782,9 @@
       }
     },
     "nanoid": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
-      "dev": true
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
     },
     "negotiator": {
       "version": "0.6.3",
@@ -9010,8 +9085,7 @@
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "picomatch": {
       "version": "2.3.1",
@@ -9612,14 +9686,12 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
     },
     "source-map-support": {
       "version": "0.5.21",
@@ -9944,6 +10016,16 @@
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true
+    },
+    "vue": {
+      "version": "2.7.13",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.13.tgz",
+      "integrity": "sha512-QnM6ULTNnPmn71eUO+4hdjfBIA3H0GLsBnchnI/kS678tjI45GOUZhXd0oP/gX9isikXz1PAzSnkPspp9EUNfQ==",
+      "peer": true,
+      "requires": {
+        "@vue/compiler-sfc": "2.7.13",
+        "csstype": "^3.1.0"
+      }
     },
     "vue-hot-reload-api": {
       "version": "2.3.4",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "sass": "^1.55.0",
     "sass-loader": "^13.1.0",
     "style-loader": "^3.3.1",
+    "vue": "^2.7.13",
     "vue-loader": "^15.10.0",
     "vue-template-compiler": "^2.7.13",
     "webpack": "^5.74.0",

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.0.0",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
-				"vue": "^2.7.13"
+				"vue": "^2.7.11"
 			},
 			"devDependencies": {
 				"@nextcloud/babel-config": "^1.0.0",
@@ -18,48 +18,79 @@
 				"@nextcloud/stylelint-config": "^2.3.0"
 			}
 		},
-		"node_modules/@babel/code-frame": {
-			"version": "7.16.0",
+		"node_modules/@ampproject/remapping": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+			"integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/highlight": "^7.16.0"
+				"@jridgewell/gen-mapping": "^0.1.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@ampproject/remapping/node_modules/@jridgewell/gen-mapping": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+			"integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/set-array": "^1.0.0",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@babel/code-frame": {
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+			"integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/highlight": "^7.18.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.16.0",
+			"version": "7.20.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.0.tgz",
+			"integrity": "sha512-Gt9jszFJYq7qzXVK4slhc6NzJXnOVmRECWcVjF/T23rNXD9NtWQ0W3qxdg+p9wWIB+VQw3GYV/U2Ha9bRTfs4w==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.16.0",
+			"version": "7.19.6",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.6.tgz",
+			"integrity": "sha512-D2Ue4KHpc6Ys2+AxpIx1BZ8+UegLLLE2p3KJEuJRKmokHOtl49jQ5ny1773KsGLZs8MQvBidAF6yWUJxRqtKtg==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.16.0",
-				"@babel/generator": "^7.16.0",
-				"@babel/helper-compilation-targets": "^7.16.0",
-				"@babel/helper-module-transforms": "^7.16.0",
-				"@babel/helpers": "^7.16.0",
-				"@babel/parser": "^7.16.0",
-				"@babel/template": "^7.16.0",
-				"@babel/traverse": "^7.16.0",
-				"@babel/types": "^7.16.0",
+				"@ampproject/remapping": "^2.1.0",
+				"@babel/code-frame": "^7.18.6",
+				"@babel/generator": "^7.19.6",
+				"@babel/helper-compilation-targets": "^7.19.3",
+				"@babel/helper-module-transforms": "^7.19.6",
+				"@babel/helpers": "^7.19.4",
+				"@babel/parser": "^7.19.6",
+				"@babel/template": "^7.18.10",
+				"@babel/traverse": "^7.19.6",
+				"@babel/types": "^7.19.4",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.1.2",
-				"semver": "^6.3.0",
-				"source-map": "^0.5.0"
+				"json5": "^2.2.1",
+				"semver": "^6.3.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -89,14 +120,15 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.16.0",
+			"version": "7.20.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.0.tgz",
+			"integrity": "sha512-GUPcXxWibClgmYJuIwC2Bc2Lg+8b9VjaJ+HlNdACEVt+Wlr1eoU1OPZjZRm7Hzl0gaTsUZNQfeihvZJhG7oc3w==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/types": "^7.16.0",
-				"jsesc": "^2.5.1",
-				"source-map": "^0.5.0"
+				"@babel/types": "^7.20.0",
+				"@jridgewell/gen-mapping": "^0.3.2",
+				"jsesc": "^2.5.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -128,14 +160,15 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.16.0",
+			"version": "7.20.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.0.tgz",
+			"integrity": "sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.16.0",
-				"@babel/helper-validator-option": "^7.14.5",
-				"browserslist": "^4.16.6",
+				"@babel/compat-data": "^7.20.0",
+				"@babel/helper-validator-option": "^7.18.6",
+				"browserslist": "^4.21.3",
 				"semver": "^6.3.0"
 			},
 			"engines": {
@@ -200,6 +233,16 @@
 				"@babel/core": "^7.4.0-0"
 			}
 		},
+		"node_modules/@babel/helper-environment-visitor": {
+			"version": "7.18.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
+			"integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
 		"node_modules/@babel/helper-explode-assignable-expression": {
 			"version": "7.16.0",
 			"dev": true,
@@ -213,38 +256,27 @@
 			}
 		},
 		"node_modules/@babel/helper-function-name": {
-			"version": "7.16.0",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
+			"integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/helper-get-function-arity": "^7.16.0",
-				"@babel/template": "^7.16.0",
-				"@babel/types": "^7.16.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-get-function-arity": {
-			"version": "7.16.0",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/types": "^7.16.0"
+				"@babel/template": "^7.18.10",
+				"@babel/types": "^7.19.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-hoist-variables": {
-			"version": "7.16.0",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
+			"integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/types": "^7.16.0"
+				"@babel/types": "^7.18.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -263,31 +295,33 @@
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.16.0",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+			"integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/types": "^7.16.0"
+				"@babel/types": "^7.18.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.16.0",
+			"version": "7.19.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.19.6.tgz",
+			"integrity": "sha512-fCmcfQo/KYr/VXXDIyd3CBGZ6AFhPFy1TfSEJ+PilGVlQT6jcbqtHAM4C1EciRqMza7/TpOUZliuSH+U6HAhJw==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.16.0",
-				"@babel/helper-replace-supers": "^7.16.0",
-				"@babel/helper-simple-access": "^7.16.0",
-				"@babel/helper-split-export-declaration": "^7.16.0",
-				"@babel/helper-validator-identifier": "^7.15.7",
-				"@babel/template": "^7.16.0",
-				"@babel/traverse": "^7.16.0",
-				"@babel/types": "^7.16.0"
+				"@babel/helper-environment-visitor": "^7.18.9",
+				"@babel/helper-module-imports": "^7.18.6",
+				"@babel/helper-simple-access": "^7.19.4",
+				"@babel/helper-split-export-declaration": "^7.18.6",
+				"@babel/helper-validator-identifier": "^7.19.1",
+				"@babel/template": "^7.18.10",
+				"@babel/traverse": "^7.19.6",
+				"@babel/types": "^7.19.4"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -344,12 +378,13 @@
 			}
 		},
 		"node_modules/@babel/helper-simple-access": {
-			"version": "7.16.0",
+			"version": "7.19.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.19.4.tgz",
+			"integrity": "sha512-f9Xq6WqBFqaDfbCzn2w85hwklswz5qsKlh7f08w4Y9yhJHpnNC0QemtSkK5YyOY8kPGvyiwdzZksGUhnGdaUIg==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/types": "^7.16.0"
+				"@babel/types": "^7.19.4"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -368,30 +403,43 @@
 			}
 		},
 		"node_modules/@babel/helper-split-export-declaration": {
-			"version": "7.16.0",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
+			"integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/types": "^7.16.0"
+				"@babel/types": "^7.18.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.15.7",
+		"node_modules/@babel/helper-string-parser": {
+			"version": "7.19.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
+			"integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
 			"dev": true,
-			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+			"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+			"dev": true,
 			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.14.5",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
+			"integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
@@ -413,26 +461,28 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.16.0",
+			"version": "7.20.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.0.tgz",
+			"integrity": "sha512-aGMjYraN0zosCEthoGLdqot1oRsmxVTQRHadsUPz5QM44Zej2PYRz7XiDE7GqnkZnNtLbOuxqoZw42vkU7+XEQ==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/template": "^7.16.0",
-				"@babel/traverse": "^7.16.0",
-				"@babel/types": "^7.16.0"
+				"@babel/template": "^7.18.10",
+				"@babel/traverse": "^7.20.0",
+				"@babel/types": "^7.20.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.16.0",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+			"integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.15.7",
+				"@babel/helper-validator-identifier": "^7.18.6",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			},
@@ -441,8 +491,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.18.6",
-			"license": "MIT",
+			"version": "7.20.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.0.tgz",
+			"integrity": "sha512-G9VgAhEaICnz8iiJeGJQyVl6J2nTjbW0xeisva0PK6XcKsga7BIaqm4ZF8Rg1Wbaqmy6znspNqhPaPkyukujzg==",
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -1528,32 +1579,35 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.16.0",
+			"version": "7.18.10",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
+			"integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.16.0",
-				"@babel/parser": "^7.16.0",
-				"@babel/types": "^7.16.0"
+				"@babel/code-frame": "^7.18.6",
+				"@babel/parser": "^7.18.10",
+				"@babel/types": "^7.18.10"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.16.0",
+			"version": "7.20.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.0.tgz",
+			"integrity": "sha512-5+cAXQNARgjRUK0JWu2UBwja4JLSO/rBMPJzpsKb+oBF5xlUuCfljQepS4XypBQoiigL0VQjTZy6WiONtUdScQ==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.16.0",
-				"@babel/generator": "^7.16.0",
-				"@babel/helper-function-name": "^7.16.0",
-				"@babel/helper-hoist-variables": "^7.16.0",
-				"@babel/helper-split-export-declaration": "^7.16.0",
-				"@babel/parser": "^7.16.0",
-				"@babel/types": "^7.16.0",
+				"@babel/code-frame": "^7.18.6",
+				"@babel/generator": "^7.20.0",
+				"@babel/helper-environment-visitor": "^7.18.9",
+				"@babel/helper-function-name": "^7.19.0",
+				"@babel/helper-hoist-variables": "^7.18.6",
+				"@babel/helper-split-export-declaration": "^7.18.6",
+				"@babel/parser": "^7.20.0",
+				"@babel/types": "^7.20.0",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
@@ -1562,12 +1616,14 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.16.0",
+			"version": "7.20.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.0.tgz",
+			"integrity": "sha512-Jlgt3H0TajCW164wkTOTzHkZb075tMQMULzrLUoUeKmO7eFL96GgDxf7/Axhc5CAuKE3KFyVW1p6ysKsi2oXAg==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.15.7",
+				"@babel/helper-string-parser": "^7.19.4",
+				"@babel/helper-validator-identifier": "^7.19.1",
 				"to-fast-properties": "^2.0.0"
 			},
 			"engines": {
@@ -1935,18 +1991,13 @@
 			"peer": true
 		},
 		"node_modules/@vue/compiler-sfc": {
-			"version": "2.7.13",
+			"version": "2.7.11",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.11.tgz",
+			"integrity": "sha512-Cf8zvrZWjROgd8yPL8Tc+O3q/Y8ZGM0Y+8blrAvj1RQsVouzUY0oHcx8BA7Hybhb90JRnzeApFrlQGZRUdYpRw==",
 			"dependencies": {
 				"@babel/parser": "^7.18.4",
 				"postcss": "^8.4.14",
 				"source-map": "^0.6.1"
-			}
-		},
-		"node_modules/@vue/compiler-sfc/node_modules/source-map": {
-			"version": "0.6.1",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/@webassemblyjs/ast": {
@@ -2195,8 +2246,9 @@
 		},
 		"node_modules/ansi-styles": {
 			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"color-convert": "^1.9.0"
@@ -2362,26 +2414,32 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.17.6",
+			"version": "4.21.4",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+			"integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
 			"dev": true,
-			"license": "MIT",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				}
+			],
 			"peer": true,
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001274",
-				"electron-to-chromium": "^1.3.886",
-				"escalade": "^3.1.1",
-				"node-releases": "^2.0.1",
-				"picocolors": "^1.0.0"
+				"caniuse-lite": "^1.0.30001400",
+				"electron-to-chromium": "^1.4.251",
+				"node-releases": "^2.0.6",
+				"update-browserslist-db": "^1.0.9"
 			},
 			"bin": {
 				"browserslist": "cli.js"
 			},
 			"engines": {
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/browserslist"
 			}
 		},
 		"node_modules/buffer-from": {
@@ -2466,19 +2524,27 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001275",
+			"version": "1.0.30001426",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001426.tgz",
+			"integrity": "sha512-n7cosrHLl8AWt0wwZw/PJZgUg3lV0gk9LMI7ikGJwhyhgsd2Nb65vKvmSexCqq/J7rbH3mFG6yZZiPR5dLPW5A==",
 			"dev": true,
-			"license": "CC-BY-4.0",
-			"peer": true,
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/browserslist"
-			}
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				}
+			],
+			"peer": true
 		},
 		"node_modules/chalk": {
 			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^3.2.1",
@@ -2501,8 +2567,9 @@
 		},
 		"node_modules/color-convert": {
 			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"color-name": "1.1.3"
@@ -2510,8 +2577,9 @@
 		},
 		"node_modules/color-name": {
 			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true
 		},
 		"node_modules/colord": {
@@ -2628,8 +2696,9 @@
 			}
 		},
 		"node_modules/csstype": {
-			"version": "3.1.0",
-			"license": "MIT"
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+			"integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
 		},
 		"node_modules/debug": {
 			"version": "4.3.4",
@@ -2793,9 +2862,10 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.3.887",
+			"version": "1.4.284",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
+			"integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
 			"dev": true,
-			"license": "ISC",
 			"peer": true
 		},
 		"node_modules/emoji-regex": {
@@ -2915,8 +2985,9 @@
 		},
 		"node_modules/escalade": {
 			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true,
 			"engines": {
 				"node": ">=6"
@@ -2924,8 +2995,9 @@
 		},
 		"node_modules/escape-string-regexp": {
 			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true,
 			"engines": {
 				"node": ">=0.8.0"
@@ -3965,8 +4037,9 @@
 		},
 		"node_modules/has-flag": {
 			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true,
 			"engines": {
 				"node": ">=4"
@@ -4451,8 +4524,9 @@
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true
 		},
 		"node_modules/js-yaml": {
@@ -4511,13 +4585,11 @@
 			"peer": true
 		},
 		"node_modules/json5": {
-			"version": "2.2.0",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+			"integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true,
-			"dependencies": {
-				"minimist": "^1.2.5"
-			},
 			"bin": {
 				"json5": "lib/cli.js"
 			},
@@ -4807,9 +4879,10 @@
 			"peer": true
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.1",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
+			"integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true
 		},
 		"node_modules/normalize-package-data": {
@@ -4977,6 +5050,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-try": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/parent-module": {
@@ -5308,15 +5391,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/read-pkg-up/node_modules/p-try": {
-			"version": "2.2.0",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/read-pkg-up/node_modules/type-fest": {
@@ -5740,10 +5814,9 @@
 			"peer": true
 		},
 		"node_modules/source-map": {
-			"version": "0.5.7",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"peer": true,
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -5764,16 +5837,6 @@
 			"dependencies": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
-			}
-		},
-		"node_modules/source-map-support/node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/spdx-correct": {
@@ -6047,8 +6110,9 @@
 		},
 		"node_modules/supports-color": {
 			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"dev": true,
-			"license": "MIT",
 			"peer": true,
 			"dependencies": {
 				"has-flag": "^3.0.0"
@@ -6355,6 +6419,33 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/update-browserslist-db": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+			"integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				}
+			],
+			"peer": true,
+			"dependencies": {
+				"escalade": "^3.1.1",
+				"picocolors": "^1.0.0"
+			},
+			"bin": {
+				"browserslist-lint": "cli.js"
+			},
+			"peerDependencies": {
+				"browserslist": ">= 4.21.0"
+			}
+		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
 			"dev": true,
@@ -6387,10 +6478,11 @@
 			}
 		},
 		"node_modules/vue": {
-			"version": "2.7.13",
-			"license": "MIT",
+			"version": "2.7.11",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-2.7.11.tgz",
+			"integrity": "sha512-VPAW5QelT7Tx6UoSw/cwx/jDROOKAK1y/Q0o7HkmVJ1WAypE7w1+UoFa+KsGxy1aYdHPU1oODB3vR6XwSfVhDg==",
 			"dependencies": {
-				"@vue/compiler-sfc": "2.7.13",
+				"@vue/compiler-sfc": "2.7.11",
 				"csstype": "^3.1.0"
 			}
 		},
@@ -6652,39 +6744,69 @@
 		}
 	},
 	"dependencies": {
-		"@babel/code-frame": {
-			"version": "7.16.0",
+		"@ampproject/remapping": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+			"integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@babel/highlight": "^7.16.0"
+				"@jridgewell/gen-mapping": "^0.1.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			},
+			"dependencies": {
+				"@jridgewell/gen-mapping": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+					"integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"@jridgewell/set-array": "^1.0.0",
+						"@jridgewell/sourcemap-codec": "^1.4.10"
+					}
+				}
+			}
+		},
+		"@babel/code-frame": {
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+			"integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@babel/highlight": "^7.18.6"
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.16.0",
+			"version": "7.20.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.0.tgz",
+			"integrity": "sha512-Gt9jszFJYq7qzXVK4slhc6NzJXnOVmRECWcVjF/T23rNXD9NtWQ0W3qxdg+p9wWIB+VQw3GYV/U2Ha9bRTfs4w==",
 			"dev": true,
 			"peer": true
 		},
 		"@babel/core": {
-			"version": "7.16.0",
+			"version": "7.19.6",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.6.tgz",
+			"integrity": "sha512-D2Ue4KHpc6Ys2+AxpIx1BZ8+UegLLLE2p3KJEuJRKmokHOtl49jQ5ny1773KsGLZs8MQvBidAF6yWUJxRqtKtg==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@babel/code-frame": "^7.16.0",
-				"@babel/generator": "^7.16.0",
-				"@babel/helper-compilation-targets": "^7.16.0",
-				"@babel/helper-module-transforms": "^7.16.0",
-				"@babel/helpers": "^7.16.0",
-				"@babel/parser": "^7.16.0",
-				"@babel/template": "^7.16.0",
-				"@babel/traverse": "^7.16.0",
-				"@babel/types": "^7.16.0",
+				"@ampproject/remapping": "^2.1.0",
+				"@babel/code-frame": "^7.18.6",
+				"@babel/generator": "^7.19.6",
+				"@babel/helper-compilation-targets": "^7.19.3",
+				"@babel/helper-module-transforms": "^7.19.6",
+				"@babel/helpers": "^7.19.4",
+				"@babel/parser": "^7.19.6",
+				"@babel/template": "^7.18.10",
+				"@babel/traverse": "^7.19.6",
+				"@babel/types": "^7.19.4",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.1.2",
-				"semver": "^6.3.0",
-				"source-map": "^0.5.0"
+				"json5": "^2.2.1",
+				"semver": "^6.3.0"
 			}
 		},
 		"@babel/eslint-parser": {
@@ -6700,13 +6822,15 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.16.0",
+			"version": "7.20.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.0.tgz",
+			"integrity": "sha512-GUPcXxWibClgmYJuIwC2Bc2Lg+8b9VjaJ+HlNdACEVt+Wlr1eoU1OPZjZRm7Hzl0gaTsUZNQfeihvZJhG7oc3w==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@babel/types": "^7.16.0",
-				"jsesc": "^2.5.1",
-				"source-map": "^0.5.0"
+				"@babel/types": "^7.20.0",
+				"@jridgewell/gen-mapping": "^0.3.2",
+				"jsesc": "^2.5.1"
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
@@ -6727,13 +6851,15 @@
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.16.0",
+			"version": "7.20.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.0.tgz",
+			"integrity": "sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@babel/compat-data": "^7.16.0",
-				"@babel/helper-validator-option": "^7.14.5",
-				"browserslist": "^4.16.6",
+				"@babel/compat-data": "^7.20.0",
+				"@babel/helper-validator-option": "^7.18.6",
+				"browserslist": "^4.21.3",
 				"semver": "^6.3.0"
 			}
 		},
@@ -6774,6 +6900,13 @@
 				"semver": "^6.1.2"
 			}
 		},
+		"@babel/helper-environment-visitor": {
+			"version": "7.18.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
+			"integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+			"dev": true,
+			"peer": true
+		},
 		"@babel/helper-explode-assignable-expression": {
 			"version": "7.16.0",
 			"dev": true,
@@ -6783,29 +6916,24 @@
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.16.0",
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
+			"integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.16.0",
-				"@babel/template": "^7.16.0",
-				"@babel/types": "^7.16.0"
-			}
-		},
-		"@babel/helper-get-function-arity": {
-			"version": "7.16.0",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@babel/types": "^7.16.0"
+				"@babel/template": "^7.18.10",
+				"@babel/types": "^7.19.0"
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.16.0",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
+			"integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@babel/types": "^7.16.0"
+				"@babel/types": "^7.18.6"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
@@ -6817,26 +6945,30 @@
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.16.0",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+			"integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@babel/types": "^7.16.0"
+				"@babel/types": "^7.18.6"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.16.0",
+			"version": "7.19.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.19.6.tgz",
+			"integrity": "sha512-fCmcfQo/KYr/VXXDIyd3CBGZ6AFhPFy1TfSEJ+PilGVlQT6jcbqtHAM4C1EciRqMza7/TpOUZliuSH+U6HAhJw==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.16.0",
-				"@babel/helper-replace-supers": "^7.16.0",
-				"@babel/helper-simple-access": "^7.16.0",
-				"@babel/helper-split-export-declaration": "^7.16.0",
-				"@babel/helper-validator-identifier": "^7.15.7",
-				"@babel/template": "^7.16.0",
-				"@babel/traverse": "^7.16.0",
-				"@babel/types": "^7.16.0"
+				"@babel/helper-environment-visitor": "^7.18.9",
+				"@babel/helper-module-imports": "^7.18.6",
+				"@babel/helper-simple-access": "^7.19.4",
+				"@babel/helper-split-export-declaration": "^7.18.6",
+				"@babel/helper-validator-identifier": "^7.19.1",
+				"@babel/template": "^7.18.10",
+				"@babel/traverse": "^7.19.6",
+				"@babel/types": "^7.19.4"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
@@ -6874,11 +7006,13 @@
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.16.0",
+			"version": "7.19.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.19.4.tgz",
+			"integrity": "sha512-f9Xq6WqBFqaDfbCzn2w85hwklswz5qsKlh7f08w4Y9yhJHpnNC0QemtSkK5YyOY8kPGvyiwdzZksGUhnGdaUIg==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@babel/types": "^7.16.0"
+				"@babel/types": "^7.19.4"
 			}
 		},
 		"@babel/helper-skip-transparent-expression-wrappers": {
@@ -6890,20 +7024,33 @@
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.16.0",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
+			"integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@babel/types": "^7.16.0"
+				"@babel/types": "^7.18.6"
 			}
 		},
+		"@babel/helper-string-parser": {
+			"version": "7.19.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
+			"integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
+			"dev": true,
+			"peer": true
+		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.15.7",
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+			"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
 			"dev": true,
 			"peer": true
 		},
 		"@babel/helper-validator-option": {
-			"version": "7.14.5",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
+			"integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
 			"dev": true,
 			"peer": true
 		},
@@ -6919,27 +7066,33 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.16.0",
+			"version": "7.20.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.0.tgz",
+			"integrity": "sha512-aGMjYraN0zosCEthoGLdqot1oRsmxVTQRHadsUPz5QM44Zej2PYRz7XiDE7GqnkZnNtLbOuxqoZw42vkU7+XEQ==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@babel/template": "^7.16.0",
-				"@babel/traverse": "^7.16.0",
-				"@babel/types": "^7.16.0"
+				"@babel/template": "^7.18.10",
+				"@babel/traverse": "^7.20.0",
+				"@babel/types": "^7.20.0"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.16.0",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+			"integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.15.7",
+				"@babel/helper-validator-identifier": "^7.18.6",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			}
 		},
 		"@babel/parser": {
-			"version": "7.18.6"
+			"version": "7.20.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.0.tgz",
+			"integrity": "sha512-G9VgAhEaICnz8iiJeGJQyVl6J2nTjbW0xeisva0PK6XcKsga7BIaqm4ZF8Rg1Wbaqmy6znspNqhPaPkyukujzg=="
 		},
 		"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
 			"version": "7.16.2",
@@ -7596,37 +7749,45 @@
 			}
 		},
 		"@babel/template": {
-			"version": "7.16.0",
+			"version": "7.18.10",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
+			"integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@babel/code-frame": "^7.16.0",
-				"@babel/parser": "^7.16.0",
-				"@babel/types": "^7.16.0"
+				"@babel/code-frame": "^7.18.6",
+				"@babel/parser": "^7.18.10",
+				"@babel/types": "^7.18.10"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.16.0",
+			"version": "7.20.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.0.tgz",
+			"integrity": "sha512-5+cAXQNARgjRUK0JWu2UBwja4JLSO/rBMPJzpsKb+oBF5xlUuCfljQepS4XypBQoiigL0VQjTZy6WiONtUdScQ==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@babel/code-frame": "^7.16.0",
-				"@babel/generator": "^7.16.0",
-				"@babel/helper-function-name": "^7.16.0",
-				"@babel/helper-hoist-variables": "^7.16.0",
-				"@babel/helper-split-export-declaration": "^7.16.0",
-				"@babel/parser": "^7.16.0",
-				"@babel/types": "^7.16.0",
+				"@babel/code-frame": "^7.18.6",
+				"@babel/generator": "^7.20.0",
+				"@babel/helper-environment-visitor": "^7.18.9",
+				"@babel/helper-function-name": "^7.19.0",
+				"@babel/helper-hoist-variables": "^7.18.6",
+				"@babel/helper-split-export-declaration": "^7.18.6",
+				"@babel/parser": "^7.20.0",
+				"@babel/types": "^7.20.0",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			}
 		},
 		"@babel/types": {
-			"version": "7.16.0",
+			"version": "7.20.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.0.tgz",
+			"integrity": "sha512-Jlgt3H0TajCW164wkTOTzHkZb075tMQMULzrLUoUeKmO7eFL96GgDxf7/Axhc5CAuKE3KFyVW1p6ysKsi2oXAg==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.15.7",
+				"@babel/helper-string-parser": "^7.19.4",
+				"@babel/helper-validator-identifier": "^7.19.1",
 				"to-fast-properties": "^2.0.0"
 			}
 		},
@@ -7889,16 +8050,13 @@
 			"peer": true
 		},
 		"@vue/compiler-sfc": {
-			"version": "2.7.13",
+			"version": "2.7.11",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.11.tgz",
+			"integrity": "sha512-Cf8zvrZWjROgd8yPL8Tc+O3q/Y8ZGM0Y+8blrAvj1RQsVouzUY0oHcx8BA7Hybhb90JRnzeApFrlQGZRUdYpRw==",
 			"requires": {
 				"@babel/parser": "^7.18.4",
 				"postcss": "^8.4.14",
 				"source-map": "^0.6.1"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1"
-				}
 			}
 		},
 		"@webassemblyjs/ast": {
@@ -8127,6 +8285,8 @@
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"dev": true,
 			"peer": true,
 			"requires": {
@@ -8247,15 +8407,16 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.17.6",
+			"version": "4.21.4",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+			"integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001274",
-				"electron-to-chromium": "^1.3.886",
-				"escalade": "^3.1.1",
-				"node-releases": "^2.0.1",
-				"picocolors": "^1.0.0"
+				"caniuse-lite": "^1.0.30001400",
+				"electron-to-chromium": "^1.4.251",
+				"node-releases": "^2.0.6",
+				"update-browserslist-db": "^1.0.9"
 			}
 		},
 		"buffer-from": {
@@ -8317,12 +8478,16 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001275",
+			"version": "1.0.30001426",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001426.tgz",
+			"integrity": "sha512-n7cosrHLl8AWt0wwZw/PJZgUg3lV0gk9LMI7ikGJwhyhgsd2Nb65vKvmSexCqq/J7rbH3mFG6yZZiPR5dLPW5A==",
 			"dev": true,
 			"peer": true
 		},
 		"chalk": {
 			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 			"dev": true,
 			"peer": true,
 			"requires": {
@@ -8340,6 +8505,8 @@
 		},
 		"color-convert": {
 			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
 			"dev": true,
 			"peer": true,
 			"requires": {
@@ -8348,6 +8515,8 @@
 		},
 		"color-name": {
 			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
 			"dev": true,
 			"peer": true
 		},
@@ -8434,7 +8603,9 @@
 			"peer": true
 		},
 		"csstype": {
-			"version": "3.1.0"
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+			"integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
 		},
 		"debug": {
 			"version": "4.3.4",
@@ -8542,7 +8713,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.887",
+			"version": "1.4.284",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
+			"integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
 			"dev": true,
 			"peer": true
 		},
@@ -8639,11 +8812,15 @@
 		},
 		"escalade": {
 			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
 			"dev": true,
 			"peer": true
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
 			"dev": true,
 			"peer": true
 		},
@@ -9402,6 +9579,8 @@
 		},
 		"has-flag": {
 			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
 			"dev": true,
 			"peer": true
 		},
@@ -9722,6 +9901,8 @@
 		},
 		"js-tokens": {
 			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
 			"dev": true,
 			"peer": true
 		},
@@ -9767,12 +9948,11 @@
 			"peer": true
 		},
 		"json5": {
-			"version": "2.2.0",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+			"integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
 			"dev": true,
-			"peer": true,
-			"requires": {
-				"minimist": "^1.2.5"
-			}
+			"peer": true
 		},
 		"kind-of": {
 			"version": "6.0.3",
@@ -9972,7 +10152,9 @@
 			"peer": true
 		},
 		"node-releases": {
-			"version": "2.0.1",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
+			"integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
 			"dev": true,
 			"peer": true
 		},
@@ -10091,6 +10273,13 @@
 			"requires": {
 				"p-limit": "^3.0.2"
 			}
+		},
+		"p-try": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"dev": true,
+			"peer": true
 		},
 		"parent-module": {
 			"version": "1.0.1",
@@ -10315,11 +10504,6 @@
 					"requires": {
 						"p-limit": "^2.2.0"
 					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"dev": true,
-					"peer": true
 				},
 				"type-fest": {
 					"version": "0.8.1",
@@ -10580,9 +10764,9 @@
 			}
 		},
 		"source-map": {
-			"version": "0.5.7",
-			"dev": true,
-			"peer": true
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 		},
 		"source-map-js": {
 			"version": "1.0.2"
@@ -10596,15 +10780,6 @@
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true,
-					"peer": true
-				}
 			}
 		},
 		"spdx-correct": {
@@ -10806,6 +10981,8 @@
 		},
 		"supports-color": {
 			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"dev": true,
 			"peer": true,
 			"requires": {
@@ -11014,6 +11191,17 @@
 			"dev": true,
 			"peer": true
 		},
+		"update-browserslist-db": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+			"integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"escalade": "^3.1.1",
+				"picocolors": "^1.0.0"
+			}
+		},
 		"uri-js": {
 			"version": "4.4.1",
 			"dev": true,
@@ -11042,9 +11230,11 @@
 			}
 		},
 		"vue": {
-			"version": "2.7.13",
+			"version": "2.7.11",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-2.7.11.tgz",
+			"integrity": "sha512-VPAW5QelT7Tx6UoSw/cwx/jDROOKAK1y/Q0o7HkmVJ1WAypE7w1+UoFa+KsGxy1aYdHPU1oODB3vR6XwSfVhDg==",
 			"requires": {
-				"@vue/compiler-sfc": "2.7.13",
+				"@vue/compiler-sfc": "2.7.11",
 				"csstype": "^3.1.0"
 			}
 		},

--- a/tests/package.json
+++ b/tests/package.json
@@ -10,9 +10,6 @@
 	},
 	"author": "John Molakvoæ <skjnldsv@protonmail.com>",
 	"license": "AGPL-3.0-or-later",
-	"dependencies": {
-		"vue": "^2.7.13"
-	},
 	"browserslist": [
 		"extends @nextcloud/browserslist-config"
 	],
@@ -21,5 +18,8 @@
 		"@nextcloud/browserslist-config": "^2.3.0",
 		"@nextcloud/eslint-config": "^8.1.2",
 		"@nextcloud/stylelint-config": "^2.3.0"
+	},
+	"dependencies": {
+		"vue": "^2.7.11"
 	}
 }


### PR DESCRIPTION
If apps/libs have their own vue dep, it makes updating this complicated as both deps needs to be updated simultaneously.
By having them all in `@nextcloud/webpack-vue-config`, we allos to upgrade them in the same flow

UPDATED: Manually downgraded the tests vue version, so that we can have a look and see if that works.
Theoretically, we should see the `@nextcloud/webpack-vue-config`'s `vue` and `vue-template-compiler` version take over as deduped dependencies. 

```bash
$ npm ls vue
webpack-vue-config-test@1.0.0 /home/admin/git/webpack-vue-config/tests
├─┬ @nextcloud/webpack-vue-config@5.4.0
│ └── vue@2.7.13 deduped
└── vue@2.7.13
```