### PR TITLE
Allow resolve to follow symlinks

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -73,6 +73,8 @@ module.exports = {
 		},
 	},
 	
+	cache: !isDev,
+	
 	optimization: {
 		chunkIds: 'named',
 		splitChunks: {


### PR DESCRIPTION
This makes sure that npm run watch will continue to update if a npm linked dependency changes

Signed-off-by: Julius Härtl <jus@bitgrid.net>