### PR TITLE
Add alias for resolving vue

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -118,5 +118,11 @@ module.exports = {
 	resolve: {
 		extensions: ['*', '.ts', '.js', '.vue'],
 		symlinks: false,
+		// Ensure npm does not duplicate vue dependency, and that npm link works for vue 3
+		// See https://github.com/vuejs/core/issues/1503
+		// See https://github.com/nextcloud/nextcloud-vue/issues/3281
+		alias: {
+			'vue$': path.resolve('./node_modules/vue')
+		},
 	},
 }


### PR DESCRIPTION
This adds an alias for resolving `vue` that prevents duplicating the vue instance. E.g. fixes https://github.com/nextcloud/nextcloud-vue/issues/3281 and is also necessary for npm linking vue3.