### PR TITLE
chore: 5.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [v5.5.0](https://github.com/nextcloud/webpack-vue-config/tree/v5.5.0) (2023-03-15)
+
+[Full Changelog](https://github.com/nextcloud/webpack-vue-config/compare/v5.4.0...v5.5.0)
+
+**Implemented enhancements:**
+
+- Add ts support [\#421](https://github.com/nextcloud/webpack-vue-config/pull/421) ([skjnldsv](https://github.com/skjnldsv))
+- Add alias for resolving vue [\#432](https://github.com/nextcloud/webpack-vue-config/pull/432) ([raimund-schluessler](https://github.com/raimund-schluessler))
+- Add public path config information for HMR [\#431](https://github.com/nextcloud/webpack-vue-config/pull/431) ([artonge](https://github.com/artonge))
+- Resolve ts files [\#424](https://github.com/nextcloud/webpack-vue-config/pull/424) ([skjnldsv](https://github.com/skjnldsv))
+
+**Fixed bugs:**
+
+- Put vue as dependency to sync with vue-template-compiler [\#371](https://github.com/nextcloud/webpack-vue-config/pull/371) ([skjnldsv](https://github.com/skjnldsv))
+
+**Merged dependencies:**
+
+- Bump @babel/core from 7.19.6 to 7.20.12 
+- Bump babel-loader from 8.2.5 to 9.1.2 
+- Bump css-loader from 6.7.1 to 6.7.3 
+- Bump json5 from 1.0.1 to 1.0.2 
+- Bump loader-utils from 1.4.0 to 1.4.2 
+- Bump sass from 1.55.0 to 1.59.2 
+- Bump sass-loader from 13.1.0 to 13.2.0 
+- Bump vue-loader from 15.10.0 to 15.10.1 
+- Bump vue-template-compiler from 2.7.13 to 2.7.14 
+- Bump webpack-cli from 4.10.0 to 5.0.1
+
 ## [v5.4.0](https://github.com/nextcloud/webpack-vue-config/tree/v5.4.0) (2022-10-25)
 
 [Full Changelog](https://github.com/nextcloud/webpack-vue-config/compare/v5.3.0...v5.4.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/webpack-vue-config",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/webpack-vue-config",
-      "version": "5.4.0",
+      "version": "5.5.0",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@babel/core": "^7.19.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/webpack-vue-config",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "description": "A webpack vue config for nextcloud apps",
   "author": "John Molakvoæ <skjnldsv@protonmail.com>",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
## [v5.5.0](https://github.com/nextcloud/webpack-vue-config/tree/v5.5.0) (2023-03-15)

[Full Changelog](https://github.com/nextcloud/webpack-vue-config/compare/v5.4.0...v5.5.0)

**Implemented enhancements:**

- Add ts support [\#421](https://github.com/nextcloud/webpack-vue-config/pull/421) ([skjnldsv](https://github.com/skjnldsv))
- Add alias for resolving vue [\#432](https://github.com/nextcloud/webpack-vue-config/pull/432) ([raimund-schluessler](https://github.com/raimund-schluessler))
- Add public path config information for HMR [\#431](https://github.com/nextcloud/webpack-vue-config/pull/431) ([artonge](https://github.com/artonge))
- Resolve ts files [\#424](https://github.com/nextcloud/webpack-vue-config/pull/424) ([skjnldsv](https://github.com/skjnldsv))

**Fixed bugs:**

- Put vue as dependency to sync with vue-template-compiler [\#371](https://github.com/nextcloud/webpack-vue-config/pull/371) ([skjnldsv](https://github.com/skjnldsv))

**Merged dependencies:**

- Bump @babel/core from 7.19.6 to 7.20.12 
- Bump babel-loader from 8.2.5 to 9.1.2 
- Bump css-loader from 6.7.1 to 6.7.3 
- Bump json5 from 1.0.1 to 1.0.2 
- Bump loader-utils from 1.4.0 to 1.4.2 
- Bump sass from 1.55.0 to 1.59.2 
- Bump sass-loader from 13.1.0 to 13.2.0 
- Bump vue-loader from 15.10.0 to 15.10.1 
- Bump vue-template-compiler from 2.7.13 to 2.7.14 
- Bump webpack-cli from 4.10.0 to 5.0.1
