### PR TITLE
Revert "Disable cache in dev mode"

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -78,9 +78,7 @@ module.exports = {
 			'Access-Control-Allow-Origin': '*',
 		},
 	},
-
-	cache: !isDev,
-
+	
 	optimization: {
 		chunkIds: 'named',
 		splitChunks: {


### PR DESCRIPTION
This makes rebuilds painfully slow (800ms to 10s!), and doesn't add much value, since the watcher can be restarted if a dependency updated (the default cache is memory, not file).

This reverts commit 520a43039d2eacbe269335898c1bcf096eab9a1c.