### PR TITLE
Update rules to prevent prettier to run

### DIFF
--- a/rules.js
+++ b/rules.js
@@ -32,6 +32,9 @@
 	RULE_VUE: {
 		test: /\.vue$/,
 		loader: 'vue-loader',
+		options: {
+			prettify: false,
+		},
 	},
 	RULE_JS: {
 		test: /\.js$/,

--- a/rules.js
+++ b/rules.js
@@ -33,6 +33,7 @@
 		test: /\.vue$/,
 		loader: 'vue-loader',
 		options: {
+			// Vue 2.7 with Prettier 3 bug. See: https://github.com/vuejs/vue/issues/13052
 			prettify: false,
 		},
 	},


### PR DESCRIPTION
Currently, the `webpack-loader` runs [prettier in development mode](https://vue-loader.vuejs.org/options.html#prettify). This is the current default. With the updated version of Prettier from 2 to 3, the [trailing comma setting changed to all](https://prettier.io/docs/en/options.html#trailing-commas). Unfortunately, the `vue-loader` chokes on the additional commas and refuses to build the Vue files.

This PR will disable the prettify step _during the Vue build_ for the development build. Thus no issue is triggered for the build with the Vue loader.

This is more of a central fix to prevent others to run into the same issue as me and needing to configure the rules locally in the apps. This is only intended as a temporary workaround until the vue loader can handle the extra commas. As the default codebase would ideally be prettified already, the impact on readability should not be too much.