### PR TITLE
fix: workaround for broken styles by BOM chars with postcss >=8.5.24 with mini-css-extract-plugin

### DIFF
--- a/rules.js
+++ b/rules.js
@@ -10,7 +10,23 @@
 	},
 	RULE_SCSS: {
 		test: /\.scss$/,
-		use: ['style-loader', 'css-loader', 'sass-loader'],
+		use: [
+			'style-loader',
+			'css-loader',
+			{
+				loader: 'sass-loader',
+				options: {
+					sassOptions: {
+						// Sass emits BOM for CSS files with non-ASCII characters in production build by default
+						// PostCSS (used in css-loader and Vue SFC compiler) starting from v8.5.24 stops removing BOM
+						// Merging these styles keeps BOM in the middle of the file, breaking the first selector of each merged stylesheet
+						// Disabling charset prevents breaking styles (a workaround until css-loader is fixed for the new PostCSS)
+						// This is safe since the document has "<meta charset="utf-8">" anyway
+						charset: false,
+					},
+				},
+			},
+		],
 	},
 	RULE_VUE: {
 		test: /\.vue$/,
@@ -33,4 +49,4 @@
 		test: /\.(png|jpe?g|gif|svg|woff2?|eot|ttf)$/,
 		type: 'asset/inline',
 	},
- }
+}


### PR DESCRIPTION
PostCSS v8.5.24 breaks styles with default `sass` options if they contain non-ASCII characters.

- PostCSS change: https://github.com/postcss/postcss/pull/2119
  - Not considered a bug/breaking change: https://github.com/postcss/postcss/issues/2122
- `css-loader` issue: https://github.com/webpack/css-loader/issues/1678
- `css-loader` fix: https://github.com/webpack/css-loader/pull/1679
- Only affects apps with merged styles, e.g., with `mini-css-extract-plugin`

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
