### PR TITLE
chore(release): v7.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 -->
 # Changelog
 
+## [7.0.3](https://github.com/nextcloud/webpack-vue-config/tree/v7.0.3) (2026-08-04)
+[Full Changelog](https://github.com/nextcloud-libraries/webpack-vue-config/compare/v7.0.2...v7.0.3)
+
+### Fixes
+* fix: workaround for broken styles by BOM chars with postcss >=8.5.24 with mini-css-extract-plugin by @ShGKme in https://github.com/nextcloud-libraries/webpack-vue-config/pull/798
+
 ## [7.0.2](https://github.com/nextcloud/webpack-vue-config/tree/v7.0.2) (2025-11-18)
 [Full Changelog](https://github.com/nextcloud-libraries/webpack-vue-config/compare/v7.0.1...v7.0.2)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/webpack-vue-config",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/webpack-vue-config",
-      "version": "7.0.2",
+      "version": "7.0.3",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/webpack-vue-config",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "description": "A webpack vue config for nextcloud apps",
   "keywords": [
     "nextcloud",


### PR DESCRIPTION
## [7.0.3](https://github.com/nextcloud/webpack-vue-config/tree/v7.0.3) (2026-08-04)
[Full Changelog](https://github.com/nextcloud-libraries/webpack-vue-config/compare/v7.0.2...v7.0.3)

### Fixes
* fix: workaround for broken styles by BOM chars with postcss >=8.5.24 with mini-css-extract-plugin by @ShGKme in https://github.com/nextcloud-libraries/webpack-vue-config/pull/798