### PR TITLE
chore(release): v7.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 -->
 # Changelog
 
+## [7.0.4](https://github.com/nextcloud/webpack-vue-config/tree/v7.0.4) (2026-08-10)
+[Full Changelog](https://github.com/nextcloud-libraries/webpack-vue-config/compare/v7.0.3...v7.0.4)
+
+### Fixes
+* fix(deps): downgrade `webpack-cli` from `7.0.0` to `6.0.1` to avoid breaking changes with `--node-env` CLI option by @ShGKme in https://github.com/nextcloud-libraries/webpack-vue-config/pull/803
+* fix(deps): downgrade broken `node-polyfill-webpack-plugin` to 4.0.0 by @ShGKme in https://github.com/nextcloud-libraries/webpack-vue-config/pull/802
+
+### Changes
+* build: replace `terser-webpack-plugin` with its actual renamed version `minimizer-webpack-plugin` by @ShGKme in https://github.com/nextcloud-libraries/webpack-vue-config/pull/805
+
+
 ## [7.0.3](https://github.com/nextcloud/webpack-vue-config/tree/v7.0.3) (2026-08-04)
 [Full Changelog](https://github.com/nextcloud-libraries/webpack-vue-config/compare/v7.0.2...v7.0.3)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/webpack-vue-config",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/webpack-vue-config",
-      "version": "7.0.3",
+      "version": "7.0.4",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/webpack-vue-config",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "description": "A webpack vue config for nextcloud apps",
   "keywords": [
     "nextcloud",


### PR DESCRIPTION
## [7.0.4](https://github.com/nextcloud/webpack-vue-config/tree/v7.0.4) (2026-08-10)
[Full Changelog](https://github.com/nextcloud-libraries/webpack-vue-config/compare/v7.0.3...v7.0.4)

### Fixes
* fix(deps): downgrade `webpack-cli` from `7.0.0` to `6.0.1` to avoid breaking changes with `--node-env` CLI option by @ShGKme in https://github.com/nextcloud-libraries/webpack-vue-config/pull/803
* fix(deps): downgrade broken `node-polyfill-webpack-plugin` to 4.0.0 by @ShGKme in https://github.com/nextcloud-libraries/webpack-vue-config/pull/802

### Changes
* build:  replace `terser-webpack-plugin` with its actual renamed version `minimizer-webpack-plugin` by @ShGKme in https://github.com/nextcloud-libraries/webpack-vue-config/pull/805